### PR TITLE
Migrate Sass from @import to the @use module system

### DIFF
--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -1,3 +1,5 @@
+@use "variables";
+
 * {
   margin: 0;
   padding: 0;
@@ -23,8 +25,8 @@ html {
 
 body {
   color: var(--text);
-  font-family: $font-family-main;
-  font-size: $font-size;
+  font-family: variables.$font-family-main;
+  font-size: variables.$font-size;
   word-wrap: break-word;
 }
 
@@ -34,7 +36,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $font-family-headings;
+  font-family: variables.$font-family-headings;
   line-height: 1.3;
   margin: 0.67em 0;
 
@@ -85,7 +87,7 @@ summary {
 
 /* ---- Responsive ---- */
 
-@media screen and (max-width: $break) {
+@media screen and (max-width: variables.$break) {
   h1 {
     font-size: 2em;
   }
@@ -112,7 +114,7 @@ summary {
   }
 }
 
-@media screen and (max-width: $sm-break) {
+@media screen and (max-width: variables.$sm-break) {
   h1 {
     font-size: 1.5em;
   }

--- a/_sass/base/_highlight.scss
+++ b/_sass/base/_highlight.scss
@@ -1,3 +1,5 @@
+@use "variables";
+
 // ==========================================================================
 //   Syntax highlighting
 // ==========================================================================
@@ -8,10 +10,10 @@ figure.highlight,
   position: relative;
   background: var(--base00);
   color: var(--base07);
-  font-family: $monospace;
-  font-size: $font-size-code;
-  line-height: $font-height-code;
-  border-radius: $border-radius;
+  font-family: variables.$monospace;
+  font-size: variables.$font-size-code;
+  line-height: variables.$font-height-code;
+  border-radius: variables.$border-radius;
 
 
   > pre,
@@ -47,11 +49,11 @@ figure.highlight {
 
 code.highlighter-rouge {
   padding: 0.2em 0.4em;
-  font-size: $font-size-code;
+  font-size: variables.$font-size-code;
   background-color: var(--code-background);
   color: var(--code-inline);
   border-radius: 2px;
-  font-family: $monospace;
+  font-family: variables.$monospace;
   //filter: invert(100%) contrast(200%);
 }
 

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -1,3 +1,5 @@
+@use "variables";
+
 // =============================================================================
 // Typography — design-system v1
 // =============================================================================
@@ -8,8 +10,8 @@
 // -----------------------------------------------------------------------------
 
 :root {
-  --font-display: #{$font-family-headings};
-  --font-body:    #{$font-family-main};
+  --font-display: #{variables.$font-family-headings};
+  --font-body:    #{variables.$font-family-main};
   --font-accent:  'Permanent Marker', 'Caveat', 'Brush Script MT', cursive;
   --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -1,43 +1,45 @@
+@use "variables";
+
 // Mix-ins
 %padding-nav {
-  padding: $padding-small $padding-x-large;
-  @media (max-width: $xl-break) {
-    padding: $padding-small ($padding-large * 2);
+  padding: variables.$padding-small variables.$padding-x-large;
+  @media (max-width: variables.$xl-break) {
+    padding: variables.$padding-small (variables.$padding-large * 2);
   }
-  @media (max-width: $l-break) {
-    padding: $padding-small $padding-large;
+  @media (max-width: variables.$l-break) {
+    padding: variables.$padding-small variables.$padding-large;
   }
-  @media (max-width: $m-break) {
-    padding: $padding-small $padding-medium;
+  @media (max-width: variables.$m-break) {
+    padding: variables.$padding-small variables.$padding-medium;
   }
-  @media (max-width: $sm-break) {
-    padding: $padding-small $padding-x-small;
+  @media (max-width: variables.$sm-break) {
+    padding: variables.$padding-small variables.$padding-x-small;
   }
 }
 
 %padding-post {
-  padding: $padding-x-small $padding-x-large;
-  @media (max-width: $xl-break) {
-    padding: $padding-x-small ($padding-large * 2);
+  padding: variables.$padding-x-small variables.$padding-x-large;
+  @media (max-width: variables.$xl-break) {
+    padding: variables.$padding-x-small (variables.$padding-large * 2);
   }
-  @media (max-width: $l-break) {
-    padding: $padding-x-small $padding-large;
+  @media (max-width: variables.$l-break) {
+    padding: variables.$padding-x-small variables.$padding-large;
   }
-  @media (max-width: $m-break) {
-    padding: $padding-x-small $padding-medium;
+  @media (max-width: variables.$m-break) {
+    padding: variables.$padding-x-small variables.$padding-medium;
   }
-  @media (max-width: $sm-break) {
-    padding: $padding-x-small $padding-small;
+  @media (max-width: variables.$sm-break) {
+    padding: variables.$padding-x-small variables.$padding-small;
   }
 }
 
 %padding-header {
-  padding: $padding-medium $padding-large;
-  @media (min-width: $xl-break) {
-    padding: $padding-large $padding-large;
+  padding: variables.$padding-medium variables.$padding-large;
+  @media (min-width: variables.$xl-break) {
+    padding: variables.$padding-large variables.$padding-large;
   }
-  @media (max-width: $sm-break) {
-    padding: $padding-large;
+  @media (max-width: variables.$sm-break) {
+    padding: variables.$padding-large;
   }
 }
 

--- a/_sass/external/_katex.scss
+++ b/_sass/external/_katex.scss
@@ -1,7 +1,9 @@
+@use "base/variables";
+
 /* Custom */
 $katex-font-path: "../../assets/fonts/katex" !default;
 .katex-display {
-  @media screen and (max-width: $sm-break) {
+  @media screen and (max-width: variables.$sm-break) {
     overflow-x: auto;
   }
   padding-bottom: 3px;

--- a/_sass/includes/_blog_nav.scss
+++ b/_sass/includes/_blog_nav.scss
@@ -1,3 +1,6 @@
+@use "base/variables";
+@use "base/utility";
+
 /* --- Pagination --- */
 .pagination {
   @extend %padding-nav;
@@ -18,7 +21,7 @@
     display: inline-block;
     vertical-align: sub;
 
-    @media (max-width: $x-sm-break) {
+    @media (max-width: variables.$x-sm-break) {
       display: none;
     }
   }

--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -1,3 +1,6 @@
+@use "base/variables";
+@use "base/utility";
+
 .site-footer {
   @extend %padding-post;
   clear: both; // article is `float: left`; without clear the footer's box overlaps the article and its border-top renders inside the page content
@@ -14,7 +17,7 @@
     text-align: left;
     align-items: start;
 
-    @media screen and (max-width: $break) {
+    @media screen and (max-width: variables.$break) {
       grid-template-columns: 1fr;
       gap: 1.5rem;
       text-align: center;
@@ -43,7 +46,7 @@
       max-width: 280px;
       margin: 0.5rem 0 0;
 
-      @media screen and (max-width: $break) {
+      @media screen and (max-width: variables.$break) {
         margin-left: auto;
         margin-right: auto;
       }

--- a/_sass/includes/_navbar.scss
+++ b/_sass/includes/_navbar.scss
@@ -1,3 +1,5 @@
+@use "base/variables";
+
 // To clear things when we float the element inside nav and ul
 .clear {
   *zoom: 1;
@@ -47,7 +49,7 @@
   .site-title {
     float: left;
     font-weight: bold;
-    font-family: $font-family-logo;
+    font-family: variables.$font-family-logo;
     font-size: 1.3em;
   }
 }
@@ -92,13 +94,13 @@ nav {
 
 /* ---- Responsive ---- */
 
-@media (min-width: $break) {
+@media (min-width: variables.$break) {
   a#pull {
     display: none;
   }
 }
 
-@media screen and (max-width: $break) {
+@media screen and (max-width: variables.$break) {
   .site-header {
     img.avatar {
       margin-top: -7px
@@ -155,7 +157,7 @@ nav {
   }
 }
 
-@media screen and (max-width: $sm-break) {
+@media screen and (max-width: variables.$sm-break) {
   .site-header {
 
     img.avatar {
@@ -170,7 +172,7 @@ nav {
 
 }
 
-@media screen and (max-width: $x-sm-break) {
+@media screen and (max-width: variables.$x-sm-break) {
   .site-header {
 
     .site-title {

--- a/_sass/includes/_portfolio.scss
+++ b/_sass/includes/_portfolio.scss
@@ -1,3 +1,5 @@
+@use "base/variables";
+
 .portfolio-link {
   display: block;
   position: relative;
@@ -33,7 +35,7 @@
       display: inline-block;
       vertical-align: middle;
 
-      @media screen and (max-width: $sm-break) {
+      @media screen and (max-width: variables.$sm-break) {
         font-size: 7px;
       }
     }

--- a/_sass/includes/_post_nav.scss
+++ b/_sass/includes/_post_nav.scss
@@ -1,3 +1,9 @@
+@use "base/variables";
+@use "layouts/posts";
+@use "base/utility";
+@use "base/global";
+@use "layouts/tags";
+
 #post-nav {
   width: 100%;
   display: inline-block;
@@ -24,7 +30,7 @@
     width: 50%;
   }
 
-  @media screen and (max-width: $sm-break) {
+  @media screen and (max-width: variables.$sm-break) {
     a, p {
       font-size: 0.8em;
     }

--- a/_sass/includes/_share_buttons.scss
+++ b/_sass/includes/_share_buttons.scss
@@ -1,6 +1,8 @@
+@use "base/variables";
+
 ul.share-buttons {
   list-style: none;
-  padding: $padding-x-small/2 0 $padding-x-small/4 0;
+  padding: variables.$padding-x-small*0.5 0 variables.$padding-x-small*0.25 0;
   margin: 0;
   text-align: center;
 

--- a/_sass/layouts/_blog.scss
+++ b/_sass/layouts/_blog.scss
@@ -1,3 +1,6 @@
+@use "base/variables";
+@use "base/utility";
+
 // Legacy .call-out block removed in design-system v1.
 // Home hero is now .iyf-hero.iyf-hero--centered (see _sass/components/_hero.scss).
 
@@ -24,12 +27,12 @@
       border-radius: 10px;
       overflow: hidden;
 
-      @media (min-width: $break) {
+      @media (min-width: variables.$break) {
         height: 250px;
       }
 
       //Smaller screen
-      @media screen and (max-width: $break) {
+      @media screen and (max-width: variables.$break) {
         height: 150px;
       }
 

--- a/_sass/layouts/_page.scss
+++ b/_sass/layouts/_page.scss
@@ -1,5 +1,8 @@
+@use "base/variables";
+@use "base/utility";
+
 .title-padder {
-  padding: $title-padding;
+  padding: variables.$title-padding;
 }
 
 h1.title {

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -1,3 +1,8 @@
+@use "base/variables";
+@use "base/utility";
+
+@use "sass:math";
+
 .comments {
   @extend %padding-post;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
@@ -99,7 +104,7 @@ header {
   header {
     color: var(--header-text);
     margin-bottom: 0;
-    padding: $padding-large/2.5 $padding-large;
+    padding: math.div(variables.$padding-large, 2.5) variables.$padding-large;
 
     .meta {
       color: var(--header-text);
@@ -118,7 +123,7 @@ header {
   }
 
   .feature-image-padding {
-    padding: $feature-image-padding;
+    padding: variables.$feature-image-padding;
   }
 }
 

--- a/_sass/layouts/_tags.scss
+++ b/_sass/layouts/_tags.scss
@@ -1,6 +1,8 @@
+@use "base/variables";
+
 .tag-list {
   width: 100%;
-  padding-bottom: $padding-x-small;
+  padding-bottom: variables.$padding-x-small;
 
   a.button {
     margin: 0.1em;
@@ -28,7 +30,7 @@
 }
 
 .tag-anchor {
-  margin-top: $padding-x-small;
+  margin-top: variables.$padding-x-small;
 
   a {
     color: var(--link);
@@ -48,7 +50,7 @@
     margin-bottom: 0;
 
     a {
-      margin-left: $padding-x-small;
+      margin-left: variables.$padding-x-small;
     }
 
     .post-info {
@@ -63,7 +65,7 @@
     line-height: normal;
   }
 
-  @media screen and (max-width: $sm-break) {
+  @media screen and (max-width: variables.$sm-break) {
     .meta {
       display: none;
     }

--- a/_sass/type-on-strap.scss
+++ b/_sass/type-on-strap.scss
@@ -2,57 +2,57 @@
 
 /* Variables */
 // All the options to customize your theme in one file
-@import 'base/variables';
+@use 'base/variables';
 
 /* Design-system base — typography placeholders + motion tokens */
-@import 'base/typography';
-@import 'base/motion';
+@use 'base/typography';
+@use 'base/motion';
 
 /* External */
 // CSS from external sources
-@import 'external/reset';
-@import 'external/pacifico';
-@import 'external/katex';
+@use 'external/reset';
+@use 'external/pacifico';
+@use 'external/katex';
 // font-awesome + source-sans-pro now load from CDN / Google Fonts via head.liquid (design-system v1)
 
 /* Base */
 // For general CSS in the theme
-@import 'base/global';
-@import 'base/highlight';
-@import 'base/utility';
+@use 'base/global';
+@use 'base/highlight';
+@use 'base/utility';
 
 /* Design-system components */
-@import 'components/button';
-@import 'components/hero';
-@import 'components/event-card';
-@import 'components/calendar-table';
-@import 'components/follow-buttons';
-@import 'components/gallery';
-@import 'components/badge';
-@import 'components/show-override';
-@import 'components/comedian-card';
-@import 'components/comedian-profile';
-@import 'components/comedian-lineup';
-@import 'components/lineup-lab';
+@use 'components/button';
+@use 'components/hero';
+@use 'components/event-card';
+@use 'components/calendar-table';
+@use 'components/follow-buttons';
+@use 'components/gallery';
+@use 'components/badge';
+@use 'components/show-override';
+@use 'components/comedian-card';
+@use 'components/comedian-profile';
+@use 'components/comedian-lineup';
+@use 'components/lineup-lab';
 
 /* Includes */
 // Linked with the html in the _includes folder
-@import 'includes/post_nav';
-@import 'includes/footer';
-@import 'includes/follow';
-@import 'includes/navbar';
-@import 'includes/share_buttons';
-@import 'includes/blog_nav';
-@import 'includes/gallery';
-@import 'includes/portfolio';
+@use 'includes/post_nav';
+@use 'includes/footer';
+@use 'includes/follow';
+@use 'includes/navbar';
+@use 'includes/share_buttons';
+@use 'includes/blog_nav';
+@use 'includes/gallery' as gallery2;
+@use 'includes/portfolio';
 
 /* Posts */
 // Linked with the html in the _layouts folder
-@import 'layouts/posts';
-@import 'layouts/blog';
-@import 'layouts/page';
-@import 'layouts/tags';
-@import 'layouts/search';
+@use 'layouts/posts';
+@use 'layouts/blog';
+@use 'layouts/page';
+@use 'layouts/tags';
+@use 'layouts/search';
 
 /**
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,4 +1,4 @@
 ---
 ---
 
-@import "type-on-strap";
+@use "type-on-strap";


### PR DESCRIPTION
## What

Kills the Sass deprecation spew that prints on every `jekyll serve`/`build`. The vendored theme stylesheet was built on `@import` (removed in Dart Sass 3.0) and `/`-division (removed in 2.0); our engine is Dart Sass (`sass-embedded` via `jekyll-sass-converter 3.1.0`), so these are real future hard-errors, not idle noise.

## How

- Ran the official `sass-migrator module --migrate-deps` and `sass-migrator division` across the live import tree (`type-on-strap.scss` + its partials). `@import` → `@use`/`@forward`, `$x/2` → `*0.5`, variables namespaced (`variables.$foo`).
- `@use` is module-scoped, so cross-file `@extend` no longer reaches globally the way `@import` did. Wired it back by hand: each file that `@extend`s a class/placeholder defined elsewhere now `@use`s that file. Covers `.subtle-txt-shadow` / `.body-link` / `.txt-shadow` and `%padding-nav` / `%padding-post` (all in `base/utility`), and `.meta` (defined across `layouts/posts`, `base/global`, and the dead `layouts/tags`).

## Verification

- Build clean, **zero** deprecation warnings.
- `check-site.rb` **79/79**.
- Compiled CSS is **rule-set identical** to master (same selectors, same declarations). The only diffs: comma-order within a few grouped selectors (no cascade effect), and the `layouts/posts`/`layouts/tags` blocks emit earlier because `@use` loads a module on first use.
- `tags`/`search` are **dead layouts** (no layout file exists, no page uses them) so that reordered block renders on no page. The one live moved block is `layouts/posts`, whose selectors are deeply scoped.

## Please eyeball on the Netlify preview

Interceptor isn't installed on this machine, so I couldn't screenshot locally. The residual risk is a cascade flip from the block reorder (low — scoped selectors, dead layouts). Worth a quick look at a **post/show page** and the **home page** on the deploy preview before merge.